### PR TITLE
Allow setting custom CSS in popup

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -50,6 +50,9 @@
   "options_hotkeys_link": {
     "message": "Edit shortcut keys"
   },
+  "options_css_link": {
+    "message": "Edit custom CSS"
+  },
   "options_save_button": {
     "message": "Save"
   },

--- a/css/options.css
+++ b/css/options.css
@@ -215,7 +215,8 @@ input[type=checkbox], input[type=radio] {
   display: none;
 }
 
-#hotkeys-link {
+#hotkeys-link,
+#css-link {
   color: gray;
   cursor: pointer;
   text-decoration: underline;

--- a/custom-css.html
+++ b/custom-css.html
@@ -1,0 +1,46 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <link rel="stylesheet" type="text/css" href="css/common.css">
+  <link rel="stylesheet" type="text/css" href="css/bootstrap.min.css">
+  <style>
+  .card {
+    margin-top: 30px;
+  }
+  .card-body {
+    padding-bottom: .25rem;
+  }
+  #custom-css-code {
+    height: 20em;
+  }
+  </style>
+
+  <script src="js/jquery-3.1.1.min.js"></script>
+  <script src="js/bootstrap.min.js"></script>
+  <script src="js/aws-sdk.js"></script>
+  <script src="js/defaults.js"></script>
+  <script src="js/custom-css.js"></script>
+</head>
+<body>
+  <div class="container">
+    <h2>Edit Custom CSS</h2>
+
+    <div class="card">
+      <div class="card-header">
+        Custom CSS in popup
+      </div>
+      <div class="card-body">
+        <form>
+          <div class="form-group">
+            <textarea class="form-control" id="custom-css-code" placeholder="Custom CSS code"></textarea>
+          </div>
+          <div class="form-group">
+            <button type="button" class="btn btn-primary" id="css-save-button">Save</button>
+          </div>
+        </form>
+      </div>
+    </div>
+
+  </div>
+</body>
+</html>

--- a/js/custom-css.js
+++ b/js/custom-css.js
@@ -1,0 +1,20 @@
+
+$(function() {
+  getSettings(["customCss"])
+    .then(function(items) {
+      let css = items.customCss || ''
+      const $element = $("#custom-css-code")
+      function update () {
+        $("#css-save-button").get(0).disabled = $element.val() === css;
+      }
+      $("#css-save-button").click(function () {
+        updateSettings({ customCss: (css = $element.val()) });
+        update();
+      });
+      $element.val(css);
+      $element.keyup(function () {
+        update();
+      });
+      update();
+    })
+})

--- a/js/options.js
+++ b/js/options.js
@@ -140,6 +140,11 @@ function initialize(allVoices, settings) {
   $("#hotkeys-link").click(function() {
     brapi.tabs.create({url: getHotkeySettingsUrl()});
   });
+
+  //hot key
+  $("#css-link").click(function() {
+    brapi.tabs.create({url: 'custom-css.html'});
+  });
 }
 
 

--- a/js/popup.js
+++ b/js/popup.js
@@ -23,6 +23,7 @@ $(function() {
 
   refreshSize();
   checkAnnouncements();
+  applyCustomCSS();
 });
 
 function handleError(err) {
@@ -245,5 +246,13 @@ function showAnnouncement(ann) {
     $("#footer a").click(function() {
       ann.disabled = true;
       updateSettings({announcement: ann});
+    })
+}
+
+function applyCustomCSS() {
+  getSettings(["customCss"])
+    .then(function(items) {
+      let css = items.customCss || ''
+      $("#custom-css").text(css)
     })
 }

--- a/options.html
+++ b/options.html
@@ -23,6 +23,8 @@
 
     <div class="form-group">
       <span id="hotkeys-link" data-i18n="options_hotkeys_link"></span>
+      &middot;
+      <span id="css-link" data-i18n="options_css_link"></span>
     </div>
 
     <div class="layout">

--- a/popup.html
+++ b/popup.html
@@ -12,6 +12,7 @@
   <script src="js/jquery-3.1.1.min.js"></script>
   <script src="js/defaults.js"></script>
   <script src="js/popup.js"></script>
+  <style id="custom-css"></style>
 </head>
 <body>
   <div id="status">


### PR DESCRIPTION
First, thanks for the extension! Made my life much more convenient. As I’m a user who prefers dark color schemes and certain font, I want to customize the CSS for the popup. This PR implements that. :)

## Screenshots

### Options

![image](https://user-images.githubusercontent.com/193136/63087943-98fc4e80-bf7d-11e9-9826-8dc6c4df62d5.png)

### Custom CSS page

![image](https://user-images.githubusercontent.com/193136/63088143-43747180-bf7e-11e9-90ca-676f02cdd8d4.png)

### Result

![image](https://user-images.githubusercontent.com/193136/63088168-54bd7e00-bf7e-11e9-8341-c0a4a6d17679.png)
