### PR TITLE
Added API for other extensions to interface

### DIFF
--- a/js/events.js
+++ b/js/events.js
@@ -4,6 +4,19 @@ var activeDoc;
 brapi.runtime.onInstalled.addListener(installContextMenus);
 if (getBrowser() == "firefox") brapi.runtime.onStartup.addListener(installContextMenus);
 
+brapi.runtime.onMessageExternal.addListener(
+  function(request, sender, sendResponse) {
+    if (request.permissions) {
+		requestPermissions({
+		  permissions: ['tabs'],
+		  origins: ['http://*/', 'https://*/'],
+		});
+    } else {
+      execCommand(request.command);
+    }
+  }
+);
+
 function installContextMenus() {
   if (brapi.contextMenus)
   brapi.contextMenus.create({
@@ -25,8 +38,7 @@ brapi.contextMenus.onClicked.addListener(function(info, tab) {
       .catch(console.error)
 })
 
-if (brapi.commands)
-brapi.commands.onCommand.addListener(function(command) {
+function execCommand(command) {
   if (command == "play") {
     getPlaybackState()
       .then(function(state) {
@@ -42,7 +54,10 @@ brapi.commands.onCommand.addListener(function(command) {
   else if (command == "stop") stop();
   else if (command == "forward") forward();
   else if (command == "rewind") rewind();
-})
+}
+
+if (brapi.commands)
+brapi.commands.onCommand.addListener(execCommand);
 
 if (brapi.ttsEngine) (function() {
   brapi.ttsEngine.onSpeak.addListener(function(utterance, options, onEvent) {

--- a/js/events.js
+++ b/js/events.js
@@ -7,10 +7,10 @@ if (getBrowser() == "firefox") brapi.runtime.onStartup.addListener(installContex
 brapi.runtime.onMessageExternal.addListener(
   function(request, sender, sendResponse) {
     if (request.permissions) {
-		requestPermissions({
-		  permissions: ['tabs'],
-		  origins: ['http://*/', 'https://*/'],
-		});
+      requestPermissions({
+        permissions: ['tabs'],
+        origins: ['http://*/', 'https://*/'],
+      });
     } else {
       execCommand(request.command);
     }

--- a/js/events.js
+++ b/js/events.js
@@ -17,6 +17,16 @@ brapi.runtime.onMessageExternal.addListener(
   }
 );
 
+brapi.runtime.onConnectExternal.addListener(
+  function(port) {
+    port.onMessage.addListener(function(msg) {
+      execCommand(msg.command, function() {
+        port.postMessage('end');
+      });
+    });
+  }
+);
+
 function installContextMenus() {
   if (brapi.contextMenus)
   brapi.contextMenus.create({
@@ -38,7 +48,7 @@ brapi.contextMenus.onClicked.addListener(function(info, tab) {
       .catch(console.error)
 })
 
-function execCommand(command) {
+function execCommand(command, onEnd) {
   if (command == "play") {
     getPlaybackState()
       .then(function(state) {
@@ -46,6 +56,7 @@ function execCommand(command) {
         else if (state == "STOPPED" || state == "PAUSED") {
           return play(function(err) {
             if (err) console.error(err);
+            if (onEnd) onEnd()
           })
         }
       })

--- a/manifest.json
+++ b/manifest.json
@@ -35,6 +35,7 @@
     "https://translate.google.com/"
   ],
   "optional_permissions": [
+    "tabs",
     "webRequest",
     "webNavigation",
     "http://*/",


### PR DESCRIPTION
Really nice job with the extension! It would be great if other extensions could interface with Read-aloud. Eg. [my extension is for voice-control](https://chrome.google.com/webstore/detail/lipsurf-voice-control-for/lnnmjmalakahagblkkcnjkoaihlfglon), and some users have asked for TTS functionality. Instead of reinventing the wheel I would rather link them to your extension and interface with it's API so that when a user says "read aloud" your read aloud extension is activated.

