### PR TITLE
Adding github action for automated submission

### DIFF
--- a/.github/workflows/submit.yml
+++ b/.github/workflows/submit.yml
@@ -1,0 +1,19 @@
+name: Submit
+
+on:
+  workflow_dispatch:
+
+jobs:
+  submit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Sync Page
+        run: npm run sync-page-scripts
+      - name: Package the archive
+        run: npm run package
+      - name: Browser Plugin Publish
+        uses: plasmo-corp/bpp@v1
+        with:
+          artifact: build/package.zip
+          keys: ${{ secrets.SUBMIT_KEYS }}

--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,4 @@ jspm_packages
 
 # Optional REPL history
 .node_repl_history
+keys.json


### PR DESCRIPTION
Hi @ken107!

Love your extension! I was looking for ways to contribute and found that since your codebase doesn't have automated ci, I thought adding that might be helpful. 

This PR added a `submit` github action workflow, which automate the zip submission process to the Chrome/Firefox/Edge stores automatically, using [bpp](https://browser.market) . It is set to run manually from the github action tab, where you can pick specific branch for each browser to submit! The only thing you would need to create is a `SUBMIT_KEYS` github repository secret.

The `SUBMIT_KEYS` secret is a json, with the schema defined [here](https://github.com/plasmo-corp/bpp/blob/v1/keys.schema.json).

Here's a sample key for you:

```json
{
  "$schema": "https://raw.githubusercontent.com/plasmo-corp/bpp/v1/keys.schema.json",
  "chrome": {
    "clientId": "123",
    "refreshToken": "789",
    "extId": "abcd"
  },
	"firefox": {
		"apiKey": "123",
		"apiSecret": "789",
		"extId": "abcd"
	},
	"edge": {
		"cookie": "123",
		"extId": "abcd"
	}
}

```

You can find instructions on how to get those keys in the schema, or if you use vscode, the schema should provide hint/intelisense when hovering over the json properties. If you need any help in setting up the keys, feel free to @ me! Otherwise if this doesn't seem necessary, feel free to close the PR :)


