### PR TITLE
Add Mac's Option Key to documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,10 +79,10 @@ Read Aloud allows you to select from a variety of text-to-speech voices, includi
 ### Shortcuts
 
 ```yaml
-ALT-P           : Play/Pause
-ALT-O           : Stop
-ALT-Comma       : Rewind
-ALT-Period      : Forward
+ALT/Option + P           : Play/Pause
+ALT/Option + O           : Stop
+ALT/Option + Comma       : Rewind
+ALT/Option + Period      : Forward
 ```
 
 ### Customization

--- a/shortcuts.html
+++ b/shortcuts.html
@@ -22,19 +22,19 @@
   <table class="table table-bordered table-striped">
     <tr>
       <td>Play/Pause</td>
-      <td>Alt-P</td>
+      <td>Alt/Option + P</td>
     </tr>
     <tr>
       <td>Stop</td>
-      <td>Alt-O</td>
+      <td>Alt/Option + O</td>
     </tr>
     <tr>
       <td>Forward</td>
-      <td>Alt-Period</td>
+      <td>Alt/Option + Period</td>
     </tr>
     <tr>
       <td>Rewind</td>
-      <td>Alt-Comma</td>
+      <td>Alt/Option + Comma</td>
     </tr>
   </table>
   </div>


### PR DESCRIPTION
Edit Shortcuts show up as Alt + (Insert Key) on Macs. Updated documentation to include the Mac's "option" key.