### PR TITLE
Nvidia Riva support

### DIFF
--- a/custom-voices.html
+++ b/custom-voices.html
@@ -105,6 +105,29 @@
       </div>
     </div>
 
+    <div class="card">
+      <div class="card-header">
+        Enter a <a href="https://github.com/kfatehi/riva_tts_proxy">Riva TTS proxy server</a> URL to enable Nvidia Riva voices. 
+      </div>
+      <div class="card-body">
+        <form>
+          <div class="form-group">
+            <div class="input-group">
+              <input type="text" class="form-control" id="riva-url" placeholder="URL" />
+              <div class="input-group-append">
+                <button type="button" class="btn btn-primary" id="riva-save-button">Save</button>
+              </div>
+            </div>
+          </div>
+          <div class="form-group">
+            <img id="riva-progress" class="status progress" src="img/loading.gif" />
+            <div id="riva-success" class="status alert alert-success"></div>
+            <div id="riva-error" class="status alert alert-danger"></div>
+          </div>
+        </form>
+      </div>
+    </div>
+
     <div class="mt-4 mb-3">
       <a href="options.html" class="btn btn-secondary">Back to Options</a>
     </div>

--- a/js/defaults.js
+++ b/js/defaults.js
@@ -185,7 +185,7 @@ function isNvidiaRiva(voice) {
 }
 
 function isRemoteVoice(voice) {
-  return isAmazonCloud(voice) || isMicrosoftCloud(voice) || isReadAloudCloud(voice) || isGoogleTranslate(voice) || isGoogleWavenet(voice) || isAmazonPolly(voice) || isIbmWatson(voice);
+  return isAmazonCloud(voice) || isMicrosoftCloud(voice) || isReadAloudCloud(voice) || isGoogleTranslate(voice) || isGoogleWavenet(voice) || isAmazonPolly(voice) || isIbmWatson(voice) || isNvidiaRiva(voice);
 }
 
 function isPremiumVoice(voice) {

--- a/js/defaults.js
+++ b/js/defaults.js
@@ -132,6 +132,7 @@ function getVoices() {
         settings.awsCreds ? amazonPollyTtsEngine.getVoices() : [],
         settings.gcpCreds ? googleWavenetTtsEngine.getVoices() : googleWavenetTtsEngine.getFreeVoices(),
         ibmWatsonTtsEngine.getVoices(),
+        nvidiaRivaTtsEngine.getVoices(),
       ])
     })
     .then(function(arr) {
@@ -177,6 +178,10 @@ function isGoogleWavenet(voice) {
 
 function isIbmWatson(voice) {
   return /^IBM-Watson /.test(voice.voiceName);
+}
+
+function isNvidiaRiva(voice) {
+  return /^Nvidia-Riva /.test(voice.voiceName);
 }
 
 function isRemoteVoice(voice) {

--- a/js/speech.js
+++ b/js/speech.js
@@ -30,6 +30,7 @@ function Speech(texts, options) {
   this.gotoEnd = gotoEnd;
 
   function pickEngine() {
+    if (isNvidiaRiva(options.voice)) return nvidiaRivaTtsEngine;
     if (isGoogleTranslate(options.voice) && !/\s(Hebrew|Telugu)$/.test(options.voice.voiceName)) {
       return googleTranslateTtsEngine.ready()
         .then(function() {return googleTranslateTtsEngine})

--- a/js/tts-engines.js
+++ b/js/tts-engines.js
@@ -1106,10 +1106,15 @@ function IbmWatsonTtsEngine() {
 
 function NvidiaRivaTtsEngine() {
   const RIVA_VOICE_PREFIX = "Nvidia-Riva "
+  var prefetchAudio;
   var isSpeaking = false;
   var audio;
   this.speak = function(utterance, options, onEvent) {
-    const urlPromise = getAudioUrl(utterance, options.voice, options.pitch, options.rate)
+    const urlPromise = Promise.resolve()
+      .then(function() {
+        if (prefetchAudio && prefetchAudio[0] == utterance && prefetchAudio[1] == options) return prefetchAudio[2];
+        else return getAudioUrl(utterance, options.voice, options.pitch, options.rate);
+      })
     // Rate supplied to player is always 1 because it is already represented in the generated audio
     audio = playAudio(urlPromise, {...options, rate: 1})
     audio.startPromise
@@ -1136,6 +1141,11 @@ function NvidiaRivaTtsEngine() {
     return audio.resume()
   };
   this.prefetch = function(utterance, options) {
+    getAudioUrl(utterance, options.voice, options.pitch, options.rate)
+      .then(function(url) {
+        prefetchAudio = [utterance, options, url];
+      })
+      .catch(console.error)
   };
   this.setNextStartTime = function() {
   };

--- a/js/tts-engines.js
+++ b/js/tts-engines.js
@@ -1110,8 +1110,8 @@ function NvidiaRivaTtsEngine() {
   var audio;
   this.speak = function(utterance, options, onEvent) {
     const urlPromise = getAudioUrl(utterance, options.voice, options.pitch, options.rate)
-    delete options['rate'] // Riva takes care of this
-    audio = playAudio(urlPromise, options)
+    // Rate supplied to player is always 1 because it is already represented in the generated audio
+    audio = playAudio(urlPromise, {...options, rate: 1})
     audio.startPromise
       .then(() => {
         onEvent({type: "start", charIndex: 0})


### PR DESCRIPTION
This PR adds support for Nvidia Riva. The Riva stack serves a gRPC service, which seemed non-trivial (impossible?) to interface with from the extension environment, so in this implementation I am relying on a companion [web service](https://github.com/kfatehi/riva_tts_proxy) that conforms an HTTP GET request similar to that used for IBM Watson for riva in order to return the desired ogg file.

# Audio Samples

[riva-english-female-1.webm](https://user-images.githubusercontent.com/175305/235287855-e7cefbcd-496b-47de-b014-e4e2e5596784.webm)

[riva-english-male-1.webm](https://user-images.githubusercontent.com/175305/235287884-8ff41351-d79d-4788-ab6e-31736449f4e9.webm)

# Screenshots

![image](https://user-images.githubusercontent.com/175305/235287343-d30b7025-8e1a-4de0-981c-7e6278ec34fd.png)

![image](https://user-images.githubusercontent.com/175305/235287348-9f9030f8-a844-4a28-88ca-d6c289963406.png)

![image](https://user-images.githubusercontent.com/175305/235287477-1a57cf19-d326-4409-a906-a150e272830b.png)
