### PR TITLE
Add checkbox to enable Google Studio voices

### DIFF
--- a/custom-voices.html
+++ b/custom-voices.html
@@ -71,6 +71,12 @@
                 <button type="button" class="btn btn-primary" id="gcp-save-button">Save</button>
               </div>
             </div>
+            <br/>
+            <div class="input-group">
+              <label for="gcp-enable-studio">
+              <input type="checkbox" id="gcp-enable-studio" name="gcp-enable-studio" value="enabled">
+              Include Google Studio voices. (WARNING: 10x cost)</label>
+            </div>
           </div>
           <div class="form-group">
             <img id="gcp-progress" class="status progress" src="img/loading.gif" />
@@ -107,7 +113,7 @@
 
     <div class="card">
       <div class="card-header">
-        Enter a <a href="https://github.com/kfatehi/riva_tts_proxy">Riva TTS proxy server</a> URL to enable Nvidia Riva voices. 
+        Enter a <a href="https://github.com/kfatehi/riva_tts_proxy">Riva TTS proxy server</a> URL to enable Nvidia Riva voices.
       </div>
       <div class="card-body">
         <form>

--- a/custom-voices.html
+++ b/custom-voices.html
@@ -113,7 +113,7 @@
 
     <div class="card">
       <div class="card-header">
-        Enter a <a href="https://github.com/kfatehi/riva_tts_proxy">Riva TTS proxy server</a> URL to enable Nvidia Riva voices.
+        Enter a <a href="https://github.com/kfatehi/riva_tts_proxy">Riva TTS proxy server</a> URL to enable Nvidia Riva voices. 
       </div>
       <div class="card-body">
         <form>

--- a/js/custom-voices.js
+++ b/js/custom-voices.js
@@ -8,6 +8,7 @@ $(function() {
       }
       if (items.gcpCreds) {
         $("#gcp-api-key").val(obfuscate(items.gcpCreds.apiKey));
+        $("#gcp-enable-studio").prop('checked', items.gcpCreds.enableStudio);
       }
       if (items.ibmCreds) {
         $("#ibm-api-key").val(obfuscate(items.ibmCreds.apiKey));
@@ -74,13 +75,18 @@ function testAws(accessKeyId, secretAccessKey) {
 function gcpSave() {
   $(".status").hide();
   var apiKey = $("#gcp-api-key").val().trim();
+  var enableStudio = $("#gcp-enable-studio").is(':checked');
   if (apiKey) {
     $("#gcp-progress").show();
     testGcp(apiKey)
       .then(function() {
         $("#gcp-progress").hide();
-        updateSettings({gcpCreds: {apiKey: apiKey}});
-        $("#gcp-success").text("Google Wavenet voices are enabled.").show();
+        updateSettings({gcpCreds: {apiKey: apiKey, enableStudio: enableStudio}});
+        if (enableStudio) {
+          $("#gcp-success").text("Google Wavenet & Studio voices are enabled.").show();
+        } else {
+          $("#gcp-success").text("Google Wavenet voices are enabled.").show();
+        }
         $("#gcp-api-key").val(obfuscate(apiKey));
       },
       function(err) {

--- a/js/defaults.js
+++ b/js/defaults.js
@@ -82,7 +82,7 @@ function parseQueryString(search) {
  */
 function getSettings(names) {
   return new Promise(function(fulfill) {
-    brapi.storage.local.get(names || ["voiceName", "rate", "pitch", "volume", "showHighlighting", "languages", "highlightFontSize", "highlightWindowSize", "preferredVoices", "useEmbeddedPlayer", "fixBtSilenceGap"], fulfill);
+    brapi.storage.local.get(names || ["voiceName", "rate", "pitch", "volume", "showHighlighting", "languages", "highlightFontSize", "highlightWindowSize", "preferredVoices", "useEmbeddedPlayer", "gcpCreds"], fulfill);
   });
 }
 
@@ -94,7 +94,7 @@ function updateSettings(items) {
 
 function clearSettings(names) {
   return new Promise(function(fulfill) {
-    brapi.storage.local.remove(names || ["voiceName", "rate", "pitch", "volume", "showHighlighting", "languages", "highlightFontSize", "highlightWindowSize", "preferredVoices", "useEmbeddedPlayer", "fixBtSilenceGap"], fulfill);
+    brapi.storage.local.remove(names || ["voiceName", "rate", "pitch", "volume", "showHighlighting", "languages", "highlightFontSize", "highlightWindowSize", "preferredVoices", "useEmbeddedPlayer"], fulfill);
   });
 }
 
@@ -178,7 +178,11 @@ function isAmazonPolly(voice) {
 }
 
 function isGoogleWavenet(voice) {
-  return /^Google(Standard|Wavenet|Neural2) /.test(voice.voiceName);
+  return /^Google(Standard|Wavenet|Neural2|Studio) /.test(voice.voiceName);
+}
+
+function isGoogleStudio(voice) {
+  return /^Google(Studio) /.test(voice.voiceName);
 }
 
 function isIbmWatson(voice) {

--- a/js/defaults.js
+++ b/js/defaults.js
@@ -82,7 +82,7 @@ function parseQueryString(search) {
  */
 function getSettings(names) {
   return new Promise(function(fulfill) {
-    brapi.storage.local.get(names || ["voiceName", "rate", "pitch", "volume", "showHighlighting", "languages", "highlightFontSize", "highlightWindowSize", "preferredVoices", "useEmbeddedPlayer"], fulfill);
+    brapi.storage.local.get(names || ["voiceName", "rate", "pitch", "volume", "showHighlighting", "languages", "highlightFontSize", "highlightWindowSize", "preferredVoices", "useEmbeddedPlayer", "fixBtSilenceGap"], fulfill);
   });
 }
 
@@ -94,7 +94,7 @@ function updateSettings(items) {
 
 function clearSettings(names) {
   return new Promise(function(fulfill) {
-    brapi.storage.local.remove(names || ["voiceName", "rate", "pitch", "volume", "showHighlighting", "languages", "highlightFontSize", "highlightWindowSize", "preferredVoices", "useEmbeddedPlayer"], fulfill);
+    brapi.storage.local.remove(names || ["voiceName", "rate", "pitch", "volume", "showHighlighting", "languages", "highlightFontSize", "highlightWindowSize", "preferredVoices", "useEmbeddedPlayer", "fixBtSilenceGap"], fulfill);
   });
 }
 

--- a/js/defaults.js
+++ b/js/defaults.js
@@ -82,7 +82,7 @@ function parseQueryString(search) {
  */
 function getSettings(names) {
   return new Promise(function(fulfill) {
-    brapi.storage.local.get(names || ["voiceName", "rate", "pitch", "volume", "showHighlighting", "languages", "highlightFontSize", "highlightWindowSize", "preferredVoices", "useEmbeddedPlayer", "gcpCreds"], fulfill);
+    brapi.storage.local.get(names || ["voiceName", "rate", "pitch", "volume", "showHighlighting", "languages", "highlightFontSize", "highlightWindowSize", "preferredVoices", "useEmbeddedPlayer"], fulfill);
   });
 }
 

--- a/js/options.js
+++ b/js/options.js
@@ -159,7 +159,7 @@ function populateVoices(allVoices, settings) {
   var allVoices = allVoices.filter(
     function(voice) {
       // include all voices or exclude only studio voices.
-      return (settings.gcpCreds.enableStudio || !isGoogleStudio(voice));
+      return ((settings.gcpCreds && settings.gcpCreds.enableStudio) || !isGoogleStudio(voice));
     });
   var voices = !selectedLangs ? allVoices : allVoices.filter(
     function(voice) {

--- a/js/options.js
+++ b/js/options.js
@@ -156,6 +156,11 @@ function initialize(allVoices, settings) {
 function populateVoices(allVoices, settings) {
   //get voices filtered by selected languages
   var selectedLangs = settings.languages && settings.languages.split(',');
+  var allVoices = allVoices.filter(
+    function(voice) {
+      // include all voices or exclude only studio voices.
+      return (settings.gcpCreds.enableStudio || !isGoogleStudio(voice));
+    });
   var voices = !selectedLangs ? allVoices : allVoices.filter(
     function(voice) {
       return !voice.lang || selectedLangs.includes(voice.lang.split('-',1)[0]);

--- a/js/options.js
+++ b/js/options.js
@@ -156,11 +156,6 @@ function initialize(allVoices, settings) {
 function populateVoices(allVoices, settings) {
   //get voices filtered by selected languages
   var selectedLangs = settings.languages && settings.languages.split(',');
-  var allVoices = allVoices.filter(
-    function(voice) {
-      // include all voices or exclude only studio voices.
-      return ((settings.gcpCreds && settings.gcpCreds.enableStudio) || !isGoogleStudio(voice));
-    });
   var voices = !selectedLangs ? allVoices : allVoices.filter(
     function(voice) {
       return !voice.lang || selectedLangs.includes(voice.lang.split('-',1)[0]);

--- a/js/tts-engines.js
+++ b/js/tts-engines.js
@@ -778,12 +778,20 @@ function GoogleWavenetTtsEngine() {
       })
   }
   function updateVoices() {
-    ajaxGet(config.serviceUrl + "/read-aloud/list-voices/google")
-      .then(JSON.parse)
-      .then(function(list) {
-        list[0].ts = Date.now();
-        updateSettings({wavenetVoices: list});
-      })
+    getSettings(["gcpCreds"]).then(function(settings) {
+      ajaxGet(config.serviceUrl + "/read-aloud/list-voices/google")
+        .then(JSON.parse)
+        .then(function(list) {
+          var creds = settings.gcpCreds;
+          var voicelist = voices.filter(
+            function(voice) {
+              // include all voices or exclude only studio voices.
+              return ((creds && creds.enableStudio) || !isGoogleStudio(voice));
+          });
+          voicelist[0].ts = Date.now() - 24*3600*1000+10;
+          updateSettings({wavenetVoices: voicelist});
+        })
+    });
   }
   function getAudioUrl(text, voice, pitch) {
     assert(text && voice);

--- a/js/tts-engines.js
+++ b/js/tts-engines.js
@@ -773,7 +773,7 @@ function GoogleWavenetTtsEngine() {
             // include all voices or exclude only studio voices.
             return ((creds && creds.enableStudio) || !isGoogleStudio(voice));
           });
-      });
+      })
   }
   this.getFreeVoices = function() {
     return this.getVoices()
@@ -789,7 +789,7 @@ function GoogleWavenetTtsEngine() {
       .then(function(list) {
         list[0].ts = Date.now();
         updateSettings({wavenetVoices: list});
-    });
+      })
   }
   function getAudioUrl(text, voice, pitch) {
     assert(text && voice);

--- a/js/tts-engines.js
+++ b/js/tts-engines.js
@@ -783,7 +783,7 @@ function GoogleWavenetTtsEngine() {
         .then(JSON.parse)
         .then(function(list) {
           var creds = settings.gcpCreds;
-          var voicelist = voices.filter(
+          var voicelist = list.filter(
             function(voice) {
               // include all voices or exclude only studio voices.
               return ((creds && creds.enableStudio) || !isGoogleStudio(voice));

--- a/js/tts-engines.js
+++ b/js/tts-engines.js
@@ -1014,7 +1014,10 @@ function GoogleWavenetTtsEngine() {
     {"voiceName":"GoogleStandard French (Daniel)","lang":"fr-FR","gender":"male"},
     {"voiceName":"GoogleStandard Italian (Bianca)","lang":"it-IT","gender":"female"},
     {"voiceName":"GoogleStandard Italian (Christopher)","lang":"it-IT","gender":"male"},
-    {"voiceName":"GoogleStandard Italian (Daniel)","lang":"it-IT","gender":"male"}
+    {"voiceName":"GoogleStandard Italian (Daniel)","lang":"it-IT","gender":"male"},
+    {"voiceName":"GoogleStudio US English (M)","lang":"en-US","gender":"male"},
+    {"voiceName":"GoogleStudio US English (O)","lang":"en-US","gender":"female"},
+    {"voiceName":"GoogleStudio US English (Q)","lang":"en-US","gender":"male"}
   ]
 }
 


### PR DESCRIPTION
This change adds a new checkbox configuration option to the "Enable Custom Voices" dialog to enable GCP Studio voices.

## Changes

* `custom-voices.html`  & `js/custom-voices.js`
  *  these changes ensure the new checkbox configuration is saved to settings and repopulated when displayed.

* `js/defaults.js` includes two changes:
  * `isGoogleWavenet()` is modified to generally recognize any Google voice, including Studio, to minimize other changes.
  * `isGoogleStudio()` is new, so that `GoogleWavenetTtsEngine.updateVoices()` can filter Studio voices based on configuration.

* `js/tts-engines.js`
  * these changes adds some new static definitions of Studio languages and adds an `isGoogleStudio` filtering step to `updateVoices()` based on the new configuration setting.

## Testing

Since the authoritative set of Google voices supported by Read Aloud are returned by https://support.readaloud.app/read-aloud/list-voices/google (which do not currently return Studio voices), I temporarily modified `GoogleWavenetTtsEngine.updateVoices()` to use the static list of voices that now include some Studio examples. This final PR reverts the changes used for testing.

## UI Changes                                                                   

The "Enable Custom Voices" dialog, that allows registration of API keys, now includes a GCP checkbox and warning.

<img width="504" alt="Screen Shot 2023-10-29 at 10 44 52 PM" src="https://github.com/ken107/read-aloud/assets/1085316/e5ccf064-a403-4459-a23f-6ddecde35af3">