### PR TITLE
Add support for Pageless documents in Google docs

### DIFF
--- a/js/content/google-doc.js
+++ b/js/content/google-doc.js
@@ -337,7 +337,6 @@ function LegacyReadAloudDoc() {
 
 function SvgReadAloudDoc() {
   var currentPageMarker, currentPageNumber
-  const $pagelessInstructionPopup = createPagelessInstructionPopup()
 
   this.getCurrentIndex = function() {
     currentPageMarker = markPage(getCurrentlyVisiblePage(getPages()))
@@ -401,12 +400,20 @@ function SvgReadAloudDoc() {
       .join(" ")
   }
 
-  function getPages() {
-    if (!$(".kix-page-paginated").length) {
-      $pagelessInstructionPopup.show(); $(document.body).one("click", () => $pagelessInstructionPopup.hide())
-      throw new Error("Cannot read aloud Google Docs in 'Pageless' mode")
+  function getDocContainer() {
+    if($(".kix-page-paginated").length) {
+      console.log("Paginated google doc detected.");
+      return $(".kix-page-paginated").get();
+    } else if($(".kix-rotatingtilemanager-content").length) {
+      console.log("Pageless google doc detected.");
+      return $(".kix-rotatingtilemanager-content").get();
+    } else {
+      console.log("Could not detect paginated or pageless google doc.");
     }
-    return $(".kix-page-paginated").get()
+  }
+
+  function getPages() {
+      return getDocContainer()
       .map(page => ({page: page, top: page.getBoundingClientRect().top}))
       .sort((a,b) => a.top-b.top)
       .map(item => item.page)
@@ -436,47 +443,5 @@ function SvgReadAloudDoc() {
       prev = text
       return true
     }
-  }
-
-  function createPagelessInstructionPopup() {
-    const $anchor = $("#docs-file-menu")
-    const anchorOffset = $anchor.offset()
-    const anchorDimension = {
-      width: $anchor.outerWidth(),
-      height: $anchor.outerHeight()
-    }
-    const $popup = $("<div>")
-      .appendTo(document.body)
-      .css({
-        position: "absolute",
-        left: anchorOffset.left + anchorDimension.width/2 - 300,
-        top: anchorOffset.top + anchorDimension.height,
-        width: 600,
-        display: "flex",
-        flexDirection: "column",
-        alignItems: "center",
-        zIndex: 999000,
-        fontSize: "larger",
-      })
-    $("<div>")
-      .appendTo($popup)
-      .css({
-        width: 0,
-        height: 0,
-        borderLeft: ".5em solid transparent",
-        borderRight: ".5em solid transparent",
-        borderBottom: ".5em solid #333",
-      })
-    $("<div>")
-      .appendTo($popup)
-      .html("Read Aloud doesn't work in 'Pageless' mode. Please go to Page Setup and change to 'Pages' mode and try again.")
-      .css({
-        marginLeft: 10 - Math.min(0, anchorOffset.left + anchorDimension.width/2 - 300),
-        backgroundColor: "#333",
-        color: "#fff",
-        padding: "1em",
-        borderRadius: ".5em",
-      })
-    return $popup.hide()
   }
 }


### PR DESCRIPTION
# Add support for Pageless documents in Google docs

Google Docs can be in two modes. Paginated and Pageless. Pageless was previously not supported by Read Aload, but this PR aims to address this.

### How to try the PR
0. Check out this branch, and load it as an Extension

1. Open a Google Doc
2. File -> Page Setup
3. Choose Pageless

Then read the document with Read Aload

![Pageless screenshot](https://github.com/ken107/read-aloud/assets/78051485/a621ad1c-31d9-474e-ba93-e88349e80501)

### Technical overview
In paginated mode the content is stored under the **"kix-page-paginated"** class. In Pageless mode the content is stored under the **"kix-rotatingtilemanager-content"**-class

### Why supporting Pageless documents is important
As an example, I am in an organization where Pageless documents are used by default (and other organizations have this as well). I cannot go around and change other peoples documents to be "Paginated". The documents can even be write-protected so it is not possible to change them to Paginated. I am sure many other people also encounter Pageless documents, so it's really good if Read Aload can read them.