### PR TITLE
Update on events.js (Access from external extensions)

### DIFF
--- a/js/events.js
+++ b/js/events.js
@@ -103,6 +103,26 @@ brapi.commands.onCommand.addListener(function(command) {
   }
 })
 
+/**
+ * Listener for external calls
+ */
+chrome.runtime.onMessageExternal.addListener(
+	(request, sender) => {
+		const myTask = request.message.substring(0, request.message.indexOf(" ")).toLowerCase();
+		const myText = request.message.substring(request.message.indexOf(" ")+1);
+		if (myTask == "play") {
+			playText(myText);
+		}
+		if (myTask == "pause") {
+			pause();
+		}
+		if (myTask == "stop") {
+			stop();
+		}
+		if (myTask == "resume") {
+			resume();
+		}
+	}); 
 
 
 /**


### PR DESCRIPTION
Added code to make ReadAloud able to listen to external messages/command. It listens to all messages that start with "play ", "pause", "stop", "resume" and execute the corresponding command. 
Example message:
`"play ReadAloud is awesome!"`
If ReadAloud receives this message, it would lead to it reading "ReadAloud is awesome!"

Example for calling ReadAloud from a different extension's content script: 
```
const readAloudID = "hdhinadidafjejdhmfkjgnolgimiaplp"; 
document.addEventListener('Read Command', function (e) {
	const data = "play " + e.detail;
	chrome.runtime.sendMessage(readAloudID, {message: data});
});
```

Only for Chrome, bc using "browser" yielded an error :(
(Sorry for any gihub or coding screw-ups, I'm fairly new to all of it)