### PR TITLE
Support the ability to merge texts into a single chunk

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -53,6 +53,15 @@
   "options_highlighting_window": {
     "message": "Show in a separate window"
   },
+  "options_merge_or_split_texts": {
+    "message": "Merge or split text"
+  },
+  "options_split_texts": {
+    "message": "Split text into multiple chunks"
+  },
+  "options_merge_texts_into_one": {
+    "message": "Merge text into one chunk"
+  },
   "options_audio_playback": {
     "message": "Audio Playback"
   },

--- a/_locales/es/messages.json
+++ b/_locales/es/messages.json
@@ -53,6 +53,15 @@
   "options_highlighting_window": {
     "message": "Mostrar en una ventana separada"
   },
+  "options_merge_or_split_texts": {
+    "message": "Fusionar o dividir texto"
+  },
+  "options_split_texts": {
+    "message": "Dividir el texto en múltiples fragmentos"
+  },
+  "options_merge_texts_into_one": {
+    "message": "Unir el texto en un solo fragmento"
+  },
   "options_audio_playback": {
     "message": "Reproducción de audio"
   },

--- a/_locales/it/messages.json
+++ b/_locales/it/messages.json
@@ -53,6 +53,15 @@
   "options_highlighting_window": {
     "message": "Mostra in una finestra separata"
   },
+  "options_merge_or_split_texts": {
+    "message": "Fondere o dividere il testo"
+  },
+  "options_split_texts": {
+    "message": "Dividere il testo in più frammenti"
+  },
+  "options_merge_texts_into_one": {
+    "message": "Unire il testo in un unico frammento"
+  },
   "options_audio_playback": {
     "message": "Riproduzione dell&#39;audio"
   },

--- a/_locales/ja/messages.json
+++ b/_locales/ja/messages.json
@@ -53,6 +53,15 @@
   "options_highlighting_window": {
     "message": "別ウィンドウで表示"
   },
+  "options_merge_or_split_texts": {
+    "message": "テキストを結合または分割する"
+  },
+  "options_split_texts": {
+    "message": "テキストを複数のチャンクに分割する"
+  },
+  "options_merge_texts_into_one": {
+    "message": "テキストを1つのチャンクに統合する"
+  },
   "options_audio_playback": {
     "message": "オーディオ再生"
   },

--- a/_locales/ru/messages.json
+++ b/_locales/ru/messages.json
@@ -53,6 +53,15 @@
   "options_highlighting_window": {
     "message": "Показать в отдельном окне"
   },
+  "options_merge_or_split_texts": {
+    "message": "Совместить или разделить текст"
+  },
+  "options_split_texts": {
+    "message": "Разделить текст на несколько частей"
+  },
+  "options_merge_texts_into_one": {
+    "message": "Совместить текст воедино"
+  },
   "options_audio_playback": {
     "message": "Воспроизведение аудио"
   },

--- a/_locales/tr/messages.json
+++ b/_locales/tr/messages.json
@@ -53,6 +53,15 @@
   "options_highlighting_window": {
     "message": "Ayrı bir pencerede göster"
   },
+  "options_merge_or_split_texts": {
+    "message": "Metni birleştir veya bölebilirsin"
+  },
+  "options_split_texts": {
+    "message": "Metni birden fazla parçaya böl"
+  },
+  "options_merge_texts_into_one": {
+    "message": "Metni tek bir parçaya birleştir"
+  },
   "options_audio_playback": {
     "message": "Ses Çalma"
   },

--- a/_locales/vi/messages.json
+++ b/_locales/vi/messages.json
@@ -53,6 +53,15 @@
   "options_highlighting_window": {
     "message": "Hiển thị trong cửa sổ riêng"
   },
+  "options_merge_or_split_texts": {
+    "message": "Kết hợp hoặc chia cắt văn bản"
+  },
+  "options_split_texts": {
+    "message": "Chia văn bản thành nhiều phần nhỏ"
+  },
+  "options_merge_texts_into_one": {
+    "message": "Hợp nhất văn bản thành một phần"
+  },
   "options_audio_playback": {
     "message": "Phát thanh"
   },

--- a/_locales/zh_CN/messages.json
+++ b/_locales/zh_CN/messages.json
@@ -53,6 +53,15 @@
   "options_highlighting_window": {
     "message": "在单独的窗口中显示"
   },
+  "options_merge_or_split_texts": {
+    "message": "合併或分割文字"
+  },
+  "options_split_texts": {
+    "message": "將文字分割成多個部分"
+  },
+  "options_merge_texts_into_one": {
+    "message": "將文字合併成一個部分"
+  },
   "options_audio_playback": {
     "message": "音频播放"
   },

--- a/_locales/zh_TW/messages.json
+++ b/_locales/zh_TW/messages.json
@@ -53,6 +53,15 @@
   "options_highlighting_window": {
     "message": "在單獨的窗口中顯示"
   },
+  "options_merge_or_split_texts": {
+    "message": "合并或拆分文本"
+  },
+  "options_split_texts": {
+    "message": "将文本分割成多个块"
+  },
+  "options_merge_texts_into_one": {
+    "message": "将文本合并为一个块"
+  },
   "options_audio_playback": {
     "message": "音頻播放"
   },

--- a/js/defaults.js
+++ b/js/defaults.js
@@ -38,6 +38,7 @@ var defaults = {
   showHighlighting: 1,
   highlightFontSize: 3,
   highlightWindowSize: 2,
+  textSplitting: 0,
 };
 
 var getSingletonAudio = lazy(() => new Audio());

--- a/js/document.js
+++ b/js/document.js
@@ -295,6 +295,9 @@ function Doc(source, onEnd) {
   async function getSpeech(texts) {
     const settings = await getSettings()
     settings.rate = await getSetting("rate" + (settings.voiceName || ""))
+    settings.textSplitting =
+      (await getSetting("textSplitting" + (settings.voiceName || ""))) ||
+      defaults.textSplitting
     var lang = (!info.detectedLang || info.lang && info.lang.startsWith(info.detectedLang)) ? info.lang : info.detectedLang;
     console.log("Declared", info.lang, "- Detected", info.detectedLang, "- Chosen", lang)
     var options = {
@@ -302,6 +305,7 @@ function Doc(source, onEnd) {
       pitch: settings.pitch || defaults.pitch,
       volume: settings.volume || defaults.volume,
       lang: config.langMap[lang] || lang || 'en-US',
+      textSplitting: `${settings.textSplitting || defaults.textSplitting}`,
     }
     const voice = await getSpeechVoice(settings.voiceName, options.lang)
     if (!voice) throw new Error(JSON.stringify({code: "error_no_voice", lang: options.lang}));

--- a/js/options.js
+++ b/js/options.js
@@ -178,6 +178,30 @@
 
 
 
+  //textSplitting
+  domReadyPromise
+    .then(() => {
+      $("#text-splitting")
+        .change(function() {
+          console.log('Setting', "textSplitting" + $("#voices").val(), $(this).val())
+          updateSetting("textSplitting" + $("#voices").val(), $(this).val())
+        })
+    })
+
+      
+  const textSplittingObservable = settingsObservable.of("voiceName")
+    .pipe(
+      rxjs.switchMap(voiceName => settingsObservable.of("textSplitting" + (voiceName || ""))),
+      rxjs.share()
+    )
+
+  rxjs.combineLatest([textSplittingObservable, domReadyPromise])
+    .subscribe(([textSplitting]) => {
+      $("#text-splitting").val(textSplitting || defaults.textSplitting)
+    })
+
+
+
   //audioPlayback
   Promise.all([brapi.storage.local.get(["useEmbeddedPlayer"]), domReadyPromise])
     .then(([settings]) => {

--- a/js/speech.js
+++ b/js/speech.js
@@ -3,6 +3,11 @@ function Speech(texts, options) {
   options.rate = (options.rate || 1) * (isGoogleNative(options.voice) ? 0.9 : 1);
 
   for (var i=0; i<texts.length; i++) if (/[\w)]$/.test(texts[i])) texts[i] += '.';
+  
+  // No text splitting
+  if (options.textSplitting === "1") {
+    texts = [texts.join("\n")];
+  }
 
   var self = this;
   var engine;
@@ -15,7 +20,7 @@ function Speech(texts, options) {
       engine = x;
     })
     .then(function() {
-      if (texts.length) texts = getChunks(texts.join("\n\n"));
+      if (texts.length && options.textSplitting !== "1") texts = getChunks(texts.join("\n\n"));
     })
 
   this.options = options;
@@ -185,6 +190,7 @@ function Speech(texts, options) {
 
   function speak(text, onEnd, onError) {
     var state = "IDLE";
+    console.log(text);
     return new Promise(function(fulfill, reject) {
       engine.speak(text, options, function(event) {
         if (event.type == "start") {

--- a/js/speech.js
+++ b/js/speech.js
@@ -190,7 +190,6 @@ function Speech(texts, options) {
 
   function speak(text, onEnd, onError) {
     var state = "IDLE";
-    console.log(text);
     return new Promise(function(fulfill, reject) {
       engine.speak(text, options, function(event) {
         if (event.type == "start") {

--- a/options.html
+++ b/options.html
@@ -92,6 +92,14 @@
         <option value="2" data-i18n="options_highlighting_window"></option>
       </select>
 
+      <div>
+        <span data-i18n="options_merge_or_split_texts"></span>
+      </div>
+      <select id="text-splitting" class="form-control">
+        <option value="0" data-i18n="options_split_texts"></option>
+        <option value="1" data-i18n="options_merge_texts_into_one"></option>
+      </select>
+
       <div class="audio-playback-visible">
         <span data-i18n="options_audio_playback"></span>
       </div>


### PR DESCRIPTION
Hi @ken107! I highly appreciate your work on this plugin!

Some TTS engines, especially neural network-based such as [Piper TTS](https://github.com/rhasspy/piper), don't work extremely well when text is being split into many chunks. It takes a noticeable amount of time to begin speaking every chunk. Therefore, the preferred way of interacting with them is often by submitting multiple sentences and paragraphs at the same time in a single chunk, so that while the first sentence is spoken, they can generate next sentences and, once ready, append them to the speech stream

Given that this is a likely direction where text-to-speech is going, and because I'd really like this feature myself, I'd like to add a support for an option to merge texts into a single chunk

The current PR is adding an dropdown named "Merge or split text" that is saved per voice with the options to either
* Split text into multiple chunks (which is a default, works the same as before), or
*  Merge text into one chunk

Here's the screenshots:
![Screenshot from 2024-02-11 00-35-19](https://github.com/ken107/read-aloud/assets/20163717/b9412ad1-133b-4f1d-bbab-5f11b702312b)
![Screenshot from 2024-02-11 00-35-35](https://github.com/ken107/read-aloud/assets/20163717/e11919de-a4f5-4de9-93d9-52b2d061afba)

Now, there is alternative and possibly better solution to the problem. Namely, we can have an input field for customizing how many paragraphs can be in a single chunk, as well as an option to make it infinite (e.g. if "-1" is specified). I'm totally willing to implement that if you think that's better!

Additionally, I'm not confident that it's wise to support this customization on anything other than native TTS engines. If you'd like me to restrict it to only native TTS engines, let me know and I'm happy to give it a go (some minor pointers would be appreciated here)

Thanks again for making and supporting this extension and for taking a look at this PR!