### PR TITLE
feat: support instructions field in OpenAI voices

### DIFF
--- a/js/tts-engines.js
+++ b/js/tts-engines.js
@@ -1018,6 +1018,7 @@ function OpenaiTtsEngine() {
         model: voiceInfo.model,
         input: text,
         voice: voiceInfo.voice,
+        instructions: voiceInfo.instructions,
         response_format: "mp3",
       })
     })


### PR DESCRIPTION
The new voice models support an instructions field that allows further customization. For example, you can make it sound like a pirate:

```json
[
  {
    "voice": "shimmer",
    "lang": "en-US",
    "model": "gpt-4o-mini-tts",
    "instructions": "Speak like a pirate"
  }
]
```