### PR TITLE
Update Chrome Web Store URL to new format

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 </div>
 
 <div align="center">
-	<a href="https://chrome.google.com/webstore/detail/read-aloud-a-text-to-spee/hdhinadidafjejdhmfkjgnolgimiaplp">Chrome Web Store</a> | <a href="https://addons.mozilla.org/en-US/firefox/addon/read-aloud/">Firefox Addon</a> | <a href="https://blog.readaloud.app/">Blog</a> | <a href="https://readaloud.app/">Website</a> 
+	<a href="https://chromewebstore.google.com/detail/read-aloud-a-text-to-spee/hdhinadidafjejdhmfkjgnolgimiaplp">Chrome Web Store</a> | <a href="https://addons.mozilla.org/en-US/firefox/addon/read-aloud/">Firefox Addon</a> | <a href="https://blog.readaloud.app/">Blog</a> | <a href="https://readaloud.app/">Website</a> 
 </div>
 
 <br>
@@ -101,7 +101,7 @@ You can change the voice, reading speed, pitch, or enable text highlighting:
 ## Installation
 
 ### Chrome and Chromium-based browsers
-You can get the latest available Read Aloud Extension version from the [Chrome Web Store](https://chrome.google.com/webstore/detail/read-aloud-a-text-to-spee/hdhinadidafjejdhmfkjgnolgimiaplp).
+You can get the latest available Read Aloud Extension version from the [Chrome Web Store](https://chromewebstore.google.com/detail/read-aloud-a-text-to-spee/hdhinadidafjejdhmfkjgnolgimiaplp).
 
 ### Firefox
 You can get the latest version of Read Aloud Extension from the [Mozilla Add-ons website](https://addons.mozilla.org/en-US/firefox/addon/read-aloud/).
@@ -120,7 +120,7 @@ You can get the latest version of Read Aloud Extension from the [Mozilla Add-ons
 
 - Star this GitHub repo :star:
 - Post about it on your social media (Twitter / Blogs / Facebook / Instagram etc).
-- Leave a positive review on the [Chrome Web Store](https://chrome.google.com/webstore/detail/read-aloud-a-text-to-spee/hdhinadidafjejdhmfkjgnolgimiaplp) or [Firefox Addon](https://addons.mozilla.org/en-US/firefox/addon/read-aloud/) pages.
+- Leave a positive review on the [Chrome Web Store](https://chromewebstore.google.com/detail/read-aloud-a-text-to-spee/hdhinadidafjejdhmfkjgnolgimiaplp) or [Firefox Addon](https://addons.mozilla.org/en-US/firefox/addon/read-aloud/) pages.
 - Create pull requests, submit bugs, suggest new features or documentation updates 🛠 
 	- To do so, go to [this page](https://github.com/ken107/read-aloud/issues) and click the *New issue* button.
 

--- a/js/defaults.js
+++ b/js/defaults.js
@@ -20,7 +20,7 @@ var config = {
     iw: 'he'
   },
   unsupportedSites: [
-    'https://chrome.google.com/webstore',
+    'https://chromewebstore.google.com',
     'https://addons.mozilla.org',
     'chrome:',
     'about:',


### PR DESCRIPTION
Updates deprecated chrome.google.com/webstore URLs to the new chromewebstore.google.com format.